### PR TITLE
test(core): fix late-suite harness regressions

### DIFF
--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -159,6 +159,10 @@ pub async fn load_default_config_for_test(codex_home: &TempDir) -> Config {
     config
 }
 
+pub fn is_default_test_model_catalog(model_catalog: &ModelsResponse) -> bool {
+    *model_catalog == build_test_model_catalog(None)
+}
+
 fn build_test_model_catalog(existing: Option<ModelsResponse>) -> ModelsResponse {
     let mut response = existing.unwrap_or_else(|| {
         serde_json::from_str(include_str!("../../models.json"))
@@ -333,7 +337,38 @@ pub fn format_with_current_shell_display_non_login(command: &str) -> String {
 }
 
 pub fn stdio_server_bin() -> Result<String, CargoBinError> {
-    codex_utils_cargo_bin::cargo_bin("test_stdio_server").map(|p| p.to_string_lossy().to_string())
+    workspace_binary("codex-rmcp-client", "test_stdio_server")
+        .map(|p| p.to_string_lossy().to_string())
+}
+
+fn workspace_binary(package: &str, binary: &str) -> Result<PathBuf, CargoBinError> {
+    match codex_utils_cargo_bin::cargo_bin(binary) {
+        Ok(path) => Ok(path),
+        Err(original_err) => {
+            if codex_utils_cargo_bin::runfiles_available() {
+                return Err(original_err);
+            }
+
+            let Ok(repo_root) = codex_utils_cargo_bin::repo_root() else {
+                return Err(original_err);
+            };
+            let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+            let status = std::process::Command::new(cargo)
+                .current_dir(repo_root.join("codex-rs"))
+                .arg("build")
+                .arg("-p")
+                .arg(package)
+                .arg("--bin")
+                .arg(binary)
+                .status();
+            match status {
+                Ok(status) if status.success() => {
+                    codex_utils_cargo_bin::cargo_bin(binary).map_err(|_| original_err)
+                }
+                _ => Err(original_err),
+            }
+        }
+    }
 }
 
 pub mod fs_wait {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -179,12 +179,16 @@ impl TestCodexBuilder {
         resume_from: Option<PathBuf>,
     ) -> anyhow::Result<TestCodex> {
         let auth = self.auth.clone();
-        let thread_manager = if let Some(model_catalog) = config.model_catalog.clone() {
+        let use_authoritative_model_catalog = config
+            .model_catalog
+            .as_ref()
+            .is_some_and(|model_catalog| !crate::is_default_test_model_catalog(model_catalog));
+        let thread_manager = if use_authoritative_model_catalog {
             ThreadManager::new(
                 config.codex_home.clone(),
                 codex_core::test_support::auth_manager_from_auth(auth.clone()),
                 SessionSource::Exec,
-                Some(model_catalog),
+                config.model_catalog.clone(),
                 CollaborationModesConfig::default(),
                 config.model_provider.clone(),
             )
@@ -559,8 +563,12 @@ pub fn test_codex() -> TestCodexBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::responses::mount_models_once;
+    use codex_core::models_manager::manager::RefreshStrategy;
+    use codex_protocol::openai_models::ModelsResponse;
     use pretty_assertions::assert_eq;
     use serde_json::json;
+    use wiremock::MockServer;
 
     #[test]
     fn custom_tool_call_output_text_returns_output_text() {
@@ -586,5 +594,116 @@ mod tests {
         })];
 
         let _ = custom_tool_call_output_text(&bodies, "call-2");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn default_test_model_catalog_still_allows_remote_model_refresh() {
+        let server = MockServer::start().await;
+        let mut remote_catalog: ModelsResponse =
+            serde_json::from_str(include_str!("../../models.json")).expect("valid models.json");
+        let remote_slug = "test-codex-builder-remote";
+        let remote_model = remote_catalog
+            .models
+            .iter_mut()
+            .find(|model| model.slug == "gpt-5.1")
+            .expect("gpt-5.1 should exist in bundled models.json");
+        remote_model.slug = remote_slug.to_string();
+        remote_model.display_name = remote_slug.to_string();
+        let models_mock = mount_models_once(
+            &server,
+            ModelsResponse {
+                models: vec![remote_model.clone()],
+            },
+        )
+        .await;
+
+        let mut builder =
+            test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+        let test = builder
+            .build(&server)
+            .await
+            .expect("build test codex with remote provider");
+
+        let available = test
+            .thread_manager
+            .get_models_manager()
+            .list_models(RefreshStrategy::OnlineIfUncached)
+            .await;
+
+        assert!(
+            available.iter().any(|model| model.model == remote_slug),
+            "default test catalog should not block remote models refresh: {available:?}"
+        );
+        assert_eq!(
+            models_mock.requests().len(),
+            1,
+            "default test catalog should still hit /models exactly once"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_model_catalog_remains_authoritative() {
+        let server = MockServer::start().await;
+        let mut remote_catalog: ModelsResponse =
+            serde_json::from_str(include_str!("../../models.json")).expect("valid models.json");
+        let remote_slug = "test-codex-builder-remote";
+        let remote_model = remote_catalog
+            .models
+            .iter_mut()
+            .find(|model| model.slug == "gpt-5.1")
+            .expect("gpt-5.1 should exist in bundled models.json");
+        remote_model.slug = remote_slug.to_string();
+        remote_model.display_name = remote_slug.to_string();
+        let models_mock = mount_models_once(
+            &server,
+            ModelsResponse {
+                models: vec![remote_model.clone()],
+            },
+        )
+        .await;
+
+        let mut custom_catalog: ModelsResponse =
+            serde_json::from_str(include_str!("../../models.json")).expect("valid models.json");
+        custom_catalog.models.truncate(1);
+        let custom_model = custom_catalog
+            .models
+            .first_mut()
+            .expect("custom catalog should include one model");
+        custom_model.slug = "custom-catalog-only".to_string();
+        custom_model.display_name = "custom-catalog-only".to_string();
+
+        let custom_catalog_for_config = custom_catalog.clone();
+        let mut builder = test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(move |config| {
+                config.model = Some("custom-catalog-only".to_string());
+                config.model_catalog = Some(custom_catalog_for_config);
+            });
+        let test = builder
+            .build(&server)
+            .await
+            .expect("build test codex with custom catalog");
+
+        let available = test
+            .thread_manager
+            .get_models_manager()
+            .list_models(RefreshStrategy::OnlineIfUncached)
+            .await;
+
+        assert!(
+            available
+                .iter()
+                .any(|model| model.model == "custom-catalog-only"),
+            "explicit custom catalog should stay available: {available:?}"
+        );
+        assert!(
+            !available.iter().any(|model| model.model == remote_slug),
+            "explicit custom catalog should ignore remote /models refresh: {available:?}"
+        );
+        assert_eq!(
+            models_mock.requests().len(),
+            0,
+            "explicit custom catalog should not fetch /models"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- keep the default injected core test model catalog additive instead of treating it as an authoritative custom catalog
- add regression tests that distinguish the default test catalog path from explicit custom model catalogs
- make `stdio_server_bin()` build `codex-rmcp-client`'s `test_stdio_server` on demand under Cargo so fresh worktrees can run the RMCP-backed core suites

## Root Cause
- `TestCodexBuilder` was routing every config with a `model_catalog` through `ThreadManager::new(...)`, which made the default injected test catalog authoritative and disabled remote `/models` refresh.
- `core` integration tests that depend on `test_stdio_server` assumed the cross-package binary was already built, which is false in a fresh worktree running only `codex-core` tests.

## Testing
- `cargo test -p core_test_support --lib -- --nocapture`
- `cargo test -p codex-core --test all suite::remote_models::remote_models_truncation_policy_with_tool_output_override -- --nocapture --exact`
- `cargo test -p codex-core --test all suite::search_tool::search_tool_selection_persists_across_turns -- --nocapture --exact`
- `cargo test -p codex-core --test all suite::truncation::mcp_tool_call_output_exceeds_limit_truncated_for_model -- --nocapture --exact`
- `cargo test -p codex-core --test all suite::rmcp_client::stdio_server_round_trip -- --nocapture --exact`
- `cargo test -p codex-core --test all suite::sqlite_state::mcp_call_marks_thread_memory_mode_polluted_when_configured -- --nocapture --exact`
- `cargo test -p codex-core --test all suite::search_tool:: -- --nocapture`
- `cargo test -p codex-core --test all suite::rmcp_client:: -- --nocapture`

Fixes #26
