### PR TITLE
fix: retry repeated transient stream disconnects

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6548,8 +6548,11 @@ async fn run_sampling_request(
         // Use the configured provider-specific stream retry budget, but still
         // allow one recovery attempt for transport disconnects when the
         // stream budget is explicitly set to zero.
-        let max_retries =
-            effective_stream_retry_budget(turn_context.provider.stream_max_retries(), &err);
+        let max_retries = effective_stream_retry_budget(
+            turn_context.provider.stream_max_retries(),
+            turn_context.provider.request_max_retries(),
+            &err,
+        );
         if retries >= max_retries
             && client_session.try_switch_fallback_transport(
                 &turn_context.session_telemetry,
@@ -6615,20 +6618,29 @@ async fn run_sampling_request(
     }
 }
 
-fn effective_stream_retry_budget(configured_max_retries: u64, err: &CodexErr) -> u64 {
-    if configured_max_retries == 0 && should_retry_once_on_transport_disconnect(err) {
-        1
-    } else {
-        configured_max_retries
+fn effective_stream_retry_budget(
+    configured_stream_max_retries: u64,
+    configured_request_max_retries: u64,
+    err: &CodexErr,
+) -> u64 {
+    if configured_stream_max_retries > 0 {
+        return configured_stream_max_retries;
     }
+    if !is_transient_transport_disconnect(err) {
+        return 0;
+    }
+    configured_request_max_retries.max(1)
 }
 
-fn should_retry_once_on_transport_disconnect(err: &CodexErr) -> bool {
+fn is_transient_transport_disconnect(err: &CodexErr) -> bool {
     match err {
-        CodexErr::Timeout | CodexErr::ConnectionFailed(_) => true,
+        CodexErr::Timeout | CodexErr::ConnectionFailed(_) | CodexErr::ResponseStreamFailed(_) => {
+            true
+        }
         CodexErr::Stream(message, _) => {
             message.contains("error sending request for url")
                 || message.contains("connection closed before message completed")
+                || message.contains("stream closed before response.completed")
                 || message.contains("connection reset")
         }
         _ => false,

--- a/codex-rs/core/src/codex_tests.rs
+++ b/codex-rs/core/src/codex_tests.rs
@@ -313,33 +313,50 @@ fn assistant_message_stream_parsers_can_be_seeded_from_output_item_added_text() 
 }
 
 #[test]
-fn effective_stream_retry_budget_allows_one_retry_for_transport_disconnect_when_disabled() {
+fn effective_stream_retry_budget_uses_request_retry_budget_for_transport_disconnects() {
     let err = CodexErr::Stream(
         "error sending request for url (https://example.com/v1/responses)".to_string(),
         None,
     );
 
-    assert_eq!(effective_stream_retry_budget(0, &err), 1);
+    assert_eq!(effective_stream_retry_budget(0, 4, &err), 4);
 }
 
 #[test]
-fn effective_stream_retry_budget_does_not_retry_once_for_non_transport_stream_error() {
+fn effective_stream_retry_budget_retries_incomplete_stream_disconnects() {
+    let err = CodexErr::Stream("stream closed before response.completed".to_string(), None);
+
+    assert_eq!(effective_stream_retry_budget(0, 4, &err), 4);
+}
+
+#[test]
+fn effective_stream_retry_budget_falls_back_to_one_retry_for_transport_disconnects() {
+    let err = CodexErr::Stream(
+        "error sending request for url (https://example.com/v1/responses)".to_string(),
+        None,
+    );
+
+    assert_eq!(effective_stream_retry_budget(0, 0, &err), 1);
+}
+
+#[test]
+fn effective_stream_retry_budget_does_not_retry_non_transport_stream_error() {
     let err = CodexErr::Stream(
         "Incomplete response returned, reason: content_filter".to_string(),
         None,
     );
 
-    assert_eq!(effective_stream_retry_budget(0, &err), 0);
+    assert_eq!(effective_stream_retry_budget(0, 4, &err), 0);
 }
 
 #[test]
-fn effective_stream_retry_budget_preserves_nonzero_configured_budget() {
+fn effective_stream_retry_budget_preserves_nonzero_stream_budget() {
     let err = CodexErr::Stream(
         "error sending request for url (https://example.com/v1/responses)".to_string(),
         None,
     );
 
-    assert_eq!(effective_stream_retry_budget(3, &err), 3);
+    assert_eq!(effective_stream_retry_budget(3, 9, &err), 3);
 }
 
 #[test]

--- a/codex-rs/core/tests/suite/cli_stream.rs
+++ b/codex-rs/core/tests/suite/cli_stream.rs
@@ -3,8 +3,11 @@ use codex_core::auth::CODEX_API_KEY_ENV_VAR;
 use codex_protocol::protocol::GitInfo;
 use codex_utils_cargo_bin::find_resource;
 use core_test_support::fs_wait;
+use core_test_support::load_sse_fixture;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
+use core_test_support::streaming_sse::StreamingSseChunk;
+use core_test_support::streaming_sse::start_streaming_sse_server;
 use serde_json::json;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -23,6 +26,12 @@ fn repo_root() -> std::path::PathBuf {
 fn cli_responses_fixture() -> std::path::PathBuf {
     #[expect(clippy::expect_used)]
     find_resource!("tests/cli_responses_fixture.sse").expect("failed to resolve fixture path")
+}
+
+fn incomplete_responses_sse() -> String {
+    let fixture = find_resource!("tests/fixtures/incomplete_sse.json")
+        .unwrap_or_else(|err| panic!("failed to resolve incomplete_sse fixture: {err}"));
+    load_sse_fixture(fixture)
 }
 
 /// Tests streaming the Responses API through the CLI using a mock server.
@@ -91,6 +100,74 @@ async fn responses_mode_stream_cli() {
     // );
     // assert!(page.items[0].thread_id.is_some(), "missing thread_id");
     // assert!(page.items[0].created_at.is_some(), "missing created_at");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_mode_stream_cli_retries_replayed_stream_request_when_stream_retries_disabled() {
+    skip_if_no_network!();
+
+    let server_responses = vec![
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_responses_sse(),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_responses_sse(),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_responses_sse(),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: responses::sse(vec![
+                responses::ev_response_created("resp-1"),
+                responses::ev_assistant_message("msg-1", "hi"),
+                responses::ev_completed("resp-1"),
+            ]),
+        }],
+    ];
+    let (server, _) = start_streaming_sse_server(server_responses).await;
+
+    let home = TempDir::new().unwrap();
+    let repo_root = repo_root();
+    let provider_override = format!(
+        "model_providers.mock={{ name = \"azure\", base_url = \"{}/v1\", env_key = \"PATH\", wire_api = \"responses\", request_max_retries = 3, stream_max_retries = 0, supports_websockets = false }}",
+        server.uri()
+    );
+    let bin = codex_utils_cargo_bin::cargo_bin("codex").unwrap();
+    let mut cmd = AssertCommand::new(bin);
+    cmd.timeout(Duration::from_secs(30));
+    cmd.arg("exec")
+        .arg("--skip-git-repo-check")
+        .arg("-c")
+        .arg(&provider_override)
+        .arg("-c")
+        .arg("model_provider=\"mock\"")
+        .arg("-C")
+        .arg(&repo_root)
+        .arg("hello?");
+    cmd.env("CODEX_HOME", home.path())
+        .env("OPENAI_API_KEY", "dummy");
+
+    let output = cmd.output().unwrap();
+    println!("Status: {}", output.status);
+    println!("Stdout:\n{}", String::from_utf8_lossy(&output.stdout));
+    println!("Stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let hi_lines = stdout.lines().filter(|line| line.trim() == "hi").count();
+    assert_eq!(hi_lines, 1, "Expected exactly one line with 'hi'");
+
+    let requests = server.requests().await;
+    assert_eq!(
+        requests.len(),
+        4,
+        "expected repeated request replay after transient stream disconnects"
+    );
+
+    server.shutdown().await;
 }
 
 /// Ensures `OPENAI_BASE_URL` still works as a deprecated fallback.

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -144,3 +144,79 @@ async fn retries_on_early_close() {
 
     server.shutdown().await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retries_replayed_stream_request_when_stream_retries_are_disabled() {
+    skip_if_no_network!();
+
+    let incomplete_sse = sse_incomplete();
+    let completed_sse = responses::sse_completed("resp_ok");
+
+    let (server, _) = start_streaming_sse_server(vec![
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_sse.clone(),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_sse.clone(),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: incomplete_sse,
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: completed_sse,
+        }],
+    ])
+    .await;
+
+    let model_provider = ModelProviderInfo {
+        name: "azure".into(),
+        base_url: Some(format!("{}/v1", server.uri())),
+        env_key: Some("PATH".into()),
+        env_key_instructions: None,
+        experimental_bearer_token: None,
+        wire_api: WireApi::Responses,
+        query_params: None,
+        http_headers: None,
+        env_http_headers: None,
+        request_max_retries: Some(3),
+        stream_max_retries: Some(0),
+        stream_idle_timeout_ms: Some(2000),
+        websocket_connect_timeout_ms: None,
+        requires_openai_auth: false,
+        supports_websockets: false,
+    };
+
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+        })
+        .build_with_streaming_server(&server)
+        .await
+        .unwrap();
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "hello".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await
+        .unwrap();
+
+    wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
+
+    let requests = server.requests().await;
+    assert_eq!(
+        requests.len(),
+        4,
+        "expected repeated request replay after transient stream disconnects"
+    );
+
+    server.shutdown().await;
+}


### PR DESCRIPTION
## Summary
- use the provider request retry budget when `stream_max_retries = 0` and the stream failed due to a transient transport disconnect
- keep zero-retry behavior for non-transport stream errors while still honoring any nonzero explicit stream retry budget
- add regressions for the core retry loop and for `codex exec` replaying repeated incomplete SSE streams

Closes #41.

## Testing
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/engineer/workspace/codex/codex-rs/target cargo test -p codex-core effective_stream_retry_budget --color never`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/engineer/workspace/codex/codex-rs/target cargo test -p codex-core --test all suite::stream_no_completed::retries_replayed_stream_request_when_stream_retries_are_disabled --color never -- --exact`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/engineer/workspace/codex/codex-rs/target cargo build -p codex-cli --bin codex --color never`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/engineer/workspace/codex/codex-rs/target cargo test -p codex-core --test all suite::cli_stream::responses_mode_stream_cli_retries_replayed_stream_request_when_stream_retries_disabled --color never -- --exact`
